### PR TITLE
Follow exec_copyout_strings more closely when setting up guest stack.

### DIFF
--- a/bsd-user/freebsd/target_os_elf.h
+++ b/bsd-user/freebsd/target_os_elf.h
@@ -85,6 +85,7 @@ struct exec
 #define DLINFO_ITEMS 12
 
 static abi_ulong target_create_elf_tables(abi_ulong p, int argc, int envc,
+                                   abi_ulong stringp,
                                    struct elfhdr * exec,
                                    abi_ulong load_addr,
                                    abi_ulong load_bias,
@@ -140,7 +141,7 @@ static abi_ulong target_create_elf_tables(abi_ulong p, int argc, int envc,
 #endif
 #undef NEW_AUX_ENT
 
-        sp = loader_build_argptr(envc, argc, sp, p, !ibcs);
+        sp = loader_build_argptr(envc, argc, sp, stringp, !ibcs);
         return sp;
 }
 

--- a/bsd-user/freebsd/target_os_vmparam.h
+++ b/bsd-user/freebsd/target_os_vmparam.h
@@ -3,7 +3,6 @@
 
 #include "target_arch_vmparam.h"
 
-#define TARGET_SPACE_USRSPACE   4096
 #define TARGET_ARG_MAX          262144
 
 /* Compare to sys/exec.h */

--- a/bsd-user/netbsd/target_os_elf.h
+++ b/bsd-user/netbsd/target_os_elf.h
@@ -146,6 +146,7 @@ struct exec
 #define DLINFO_ITEMS 12
 
 static abi_ulong target_create_elf_tables(abi_ulong p, int argc, int envc,
+                                   abi_ulong stringp,
                                    struct elfhdr * exec,
                                    abi_ulong load_addr,
                                    abi_ulong load_bias,
@@ -219,7 +220,7 @@ static abi_ulong target_create_elf_tables(abi_ulong p, int argc, int envc,
 #endif
 #undef NEW_AUX_ENT
 
-        sp = loader_build_argptr(envc, argc, sp, p, !ibcs);
+        sp = loader_build_argptr(envc, argc, sp, stringp, !ibcs);
         return sp;
 }
 

--- a/bsd-user/netbsd/target_os_stack.h
+++ b/bsd-user/netbsd/target_os_stack.h
@@ -3,7 +3,8 @@
 
 #include "target_arch_sigtramp.h"
 
-static inline int setup_initial_stack(struct bsd_binprm *bprm, abi_ulong *p)
+static inline int setup_initial_stack(struct bsd_binprm *bprm, abi_ulong *p,
+    abi_ulong *stringp)
 {
     int i;
     abi_ulong stack_base;
@@ -12,6 +13,9 @@ static inline int setup_initial_stack(struct bsd_binprm *bprm, abi_ulong *p)
                   MAX_ARG_PAGES * TARGET_PAGE_SIZE;
     if (p) {
         *p = stack_base;
+    }
+    if (stringp) {
+	*stringp = stack_base;
     }
 
     for (i = 0; i < MAX_ARG_PAGES; i++) {

--- a/bsd-user/openbsd/target_os_elf.h
+++ b/bsd-user/openbsd/target_os_elf.h
@@ -146,6 +146,7 @@ struct exec
 #define DLINFO_ITEMS 12
 
 static abi_ulong target_create_elf_tables(abi_ulong p, int argc, int envc,
+                                   abi_ulong stringp,
                                    struct elfhdr * exec,
                                    abi_ulong load_addr,
                                    abi_ulong load_bias,
@@ -219,7 +220,7 @@ static abi_ulong target_create_elf_tables(abi_ulong p, int argc, int envc,
 #endif
 #undef NEW_AUX_ENT
 
-        sp = loader_build_argptr(envc, argc, sp, p, !ibcs);
+        sp = loader_build_argptr(envc, argc, sp, stringp, !ibcs);
         return sp;
 }
 

--- a/bsd-user/openbsd/target_os_stack.h
+++ b/bsd-user/openbsd/target_os_stack.h
@@ -3,7 +3,8 @@
 
 #include "target_arch_sigtramp.h"
 
-static inline int setup_initial_stack(struct bsd_binprm *bprm, abi_ulong *p)
+static inline int setup_initial_stack(struct bsd_binprm *bprm, abi_ulong *p,
+    abi_ulong *stringp)
 {
     int i;
     abi_ulong stack_base;
@@ -12,6 +13,9 @@ static inline int setup_initial_stack(struct bsd_binprm *bprm, abi_ulong *p)
                   MAX_ARG_PAGES * TARGET_PAGE_SIZE;
     if (p) {
         *p = stack_base;
+    }
+    if (stringp) {
+        *stringp = stack_base;
     }
 
     for (i = 0; i < MAX_ARG_PAGES; i++) {

--- a/bsd-user/qemu.h
+++ b/bsd-user/qemu.h
@@ -134,6 +134,7 @@ struct bsd_binprm {
         char buf[128];
         void *page[MAX_ARG_PAGES];
         abi_ulong p;
+        abi_ulong stringp;
         int fd;
         int e_uid, e_gid;
         int argc, envc;


### PR DESCRIPTION
Remove mysterious TARGET_SPACE_USRSPACE define that limited the
compined size of argvp and envp vectors to just 4k and use the same
calculation that FreeBSD kernel uses to allocate the space for
strings and vectors sans aux vector, which we do not support just
yet. Remove assumption that argv and env strings end up at the top
of the stack and pass the pointer around instead.

This allows one to run programs with more than 4096/sizeof(abi_long)
env and args strings on command line.
