### PR TITLE
Revert "Implement same thread pointer semantics as in FreeBSD kernel."

### DIFF
--- a/bsd-user/mips/target_arch_cpu.c
+++ b/bsd-user/mips/target_arch_cpu.c
@@ -16,14 +16,12 @@
  */
 #include "target_arch.h"
 
-#define TP_OFFSET	0x7008
-
 void target_cpu_set_tls(CPUMIPSState *env, target_ulong newtls)
 {
-    env->active_tc.CP0_UserLocal = newtls + TP_OFFSET;
+    env->active_tc.CP0_UserLocal = newtls;
 }
 
 target_ulong target_cpu_get_tls(CPUMIPSState *env)
 {
-    return (env->active_tc.CP0_UserLocal - TP_OFFSET);
+    return (env->active_tc.CP0_UserLocal);
 }

--- a/bsd-user/mips/target_arch_signal.h
+++ b/bsd-user/mips/target_arch_signal.h
@@ -82,10 +82,6 @@ struct target_sigframe {
     uint32_t    __spare__[2];
 };
 
-/* Forward declare due to unfortunate header nesting */
-void target_cpu_set_tls(CPUMIPSState *env, target_ulong newtls);
-target_ulong target_cpu_get_tls(CPUMIPSState *env);
-
 /*
  * Compare to mips/mips/pm_machdep.c sendsig()
  * Assumes that target stack frame memory is locked.
@@ -176,7 +172,7 @@ static inline abi_long get_mcontext(CPUMIPSState *regs, target_mcontext_t *mcp,
     mcp->mc_pc = tswapal(regs->active_tc.PC);
     mcp->mullo = tswapal(regs->active_tc.LO[0]);
     mcp->mulhi = tswapal(regs->active_tc.HI[0]);
-    mcp->mc_tls = tswapal(target_cpu_get_tls(regs));
+    mcp->mc_tls = tswapal(regs->active_tc.CP0_UserLocal);
 
     /* Don't do any of the status and cause registers. */
 
@@ -216,7 +212,7 @@ static inline abi_long set_mcontext(CPUMIPSState *regs, target_mcontext_t *mcp,
     regs->CP0_EPC = tswapal(mcp->mc_pc);
     regs->active_tc.LO[0] = tswapal(mcp->mullo);
     regs->active_tc.HI[0] = tswapal(mcp->mulhi);
-    target_cpu_set_tls(regs, tswapal(mcp->mc_tls));
+    regs->active_tc.CP0_UserLocal = tswapal(mcp->mc_tls);
 
     if (srflag) {
         /* doing sigreturn() */

--- a/bsd-user/mips64/target_arch_cpu.c
+++ b/bsd-user/mips64/target_arch_cpu.c
@@ -16,14 +16,12 @@
  */
 #include "target_arch.h"
 
-#define TP_OFFSET	0x7010
-
 void target_cpu_set_tls(CPUMIPSState *env, target_ulong newtls)
 {
-    env->active_tc.CP0_UserLocal = newtls + TP_OFFSET;
+    env->active_tc.CP0_UserLocal = newtls;
 }
 
 target_ulong target_cpu_get_tls(CPUMIPSState *env)
 {
-    return (env->active_tc.CP0_UserLocal - TP_OFFSET);
+    return (env->active_tc.CP0_UserLocal);
 }

--- a/bsd-user/mips64/target_arch_signal.h
+++ b/bsd-user/mips64/target_arch_signal.h
@@ -81,10 +81,6 @@ struct target_sigframe {
     uint32_t    __spare__[2];
 };
 
-/* Forward declare due to unfortunate header nesting */
-void target_cpu_set_tls(CPUMIPSState *env, target_ulong newtls);
-target_ulong target_cpu_get_tls(CPUMIPSState *env);
-
 /*
  * Compare to mips/mips/pm_machdep.c sendsig()
  * Assumes that target stack frame memory is locked.
@@ -164,7 +160,7 @@ static inline abi_long get_mcontext(CPUMIPSState *regs, target_mcontext_t *mcp,
     mcp->mc_pc = tswapal(regs->active_tc.PC);
     mcp->mullo = tswapal(regs->active_tc.LO[0]);
     mcp->mulhi = tswapal(regs->active_tc.HI[0]);
-    mcp->mc_tls = tswapal(target_cpu_get_tls(regs));
+    mcp->mc_tls = tswapal(regs->active_tc.CP0_UserLocal);
 
     /* Don't do any of the status and cause registers. */
 
@@ -193,7 +189,7 @@ static inline abi_long set_mcontext(CPUMIPSState *regs, target_mcontext_t *mcp,
     regs->CP0_EPC = tswapal(mcp->mc_pc);
     regs->active_tc.LO[0] = tswapal(mcp->mullo);
     regs->active_tc.HI[0] = tswapal(mcp->mulhi);
-    target_cpu_set_tls(regs, tswapal(mcp->mc_tls));
+    regs->active_tc.CP0_UserLocal = tswapal(mcp->mc_tls);
 
     if (srflag) {
         /* doing sigreturn() */


### PR DESCRIPTION
Reverts seanbruno/qemu-bsd-user#9

Nope this as we are going to break the ABI in head for MIPS/MIPS64 instead.  This will be fixed by a newer version of the jail and does not require changes to qemu.