### PR TITLE
Due to the way we use exceptions to emulate TLS and RAS for armv4/v5,…

### DIFF
--- a/bsd-user/signal.c
+++ b/bsd-user/signal.c
@@ -455,9 +455,12 @@ static void host_signal_handler(int host_signum, siginfo_t *info, void *puc)
      */
     if ((host_signum == SIGSEGV || host_signum == SIGBUS) &&
             info->si_code < 0x10000) {
+        start_exclusive();
         if (cpu_signal_handler(host_signum, info, puc)) {
+            end_exclusive();
             return;
         }
+        end_exclusive();
     }
 
     /* Get the target signal number. */


### PR DESCRIPTION
… we gotta

make cpu_signal_handler() exclusive. The trick is, cpu_signal_handler() never
returns, it just siglongjmps() to the main loop, so try to work around this.u
exclusive.