### PR TITLE
Add a hack to work around a procfs(5) issue.

### DIFF
--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -677,7 +677,7 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
         break;
 
     case TARGET_FREEBSD_NR_readlink: /* readlink(2) */
-        ret = do_bsd_readlink(arg1, arg2, arg3);
+        ret = do_bsd_readlink(cpu_env, arg1, arg2, arg3);
         break;
 
     case TARGET_FREEBSD_NR_readlinkat: /* readlinkat(2) */


### PR DESCRIPTION
Intercept readlink(2) to return actual command, not the path to QEMU itself.
Note this solves very special cases, e.g., OpenJDK8 build with Poudriere.