### PR TITLE
os-sys: Fix build on FreeBSD 9.

### DIFF
--- a/bsd-user/freebsd/os-sys.c
+++ b/bsd-user/freebsd/os-sys.c
@@ -652,8 +652,9 @@ static int sysctl_oldcvt(void *holdp, size_t *holdlen, uint32_t kind)
 	 */
 	if ((*holdlen > sizeof(abi_ulong)) && ((*holdlen % sizeof(abi_ulong)) == 0) ) {
 		int array_size = *holdlen / sizeof(long);
+		int i;
 		if (holdp) {
-			for (int i = 0; i < array_size; i++) {
+			for (i = 0; i < array_size; i++) {
 				((uint32_t *)holdp)[i] = tswap32(((long *)holdp)[i]);
 			}
 			*holdlen = array_size * sizeof(abi_ulong);


### PR DESCRIPTION
```
/wrkdirs/usr/ports/emulators/qemu-user-static/work/qemu-bsd-user-182181a/bsd-user/freebsd/os-sys.c: In function 'sysctl_oldcvt':
/wrkdirs/usr/ports/emulators/qemu-user-static/work/qemu-bsd-user-182181a/bsd-user/freebsd/os-sys.c:656: error: 'for' loop initial declaration used outside C99 mode
/wrkdirs/usr/ports/emulators/qemu-user-static/work/qemu-bsd-user-182181a/rules.mak:57: recipe for target 'bsd-user/freebsd/os-sys.o' failed
```

Declare `i` outside the for loop to make it build with base GCC.