### PR TITLE
Allow utimensat() syscall on FreeBSD 10.3, where pkg(8) requires it.

### DIFF
--- a/bsd-user/freebsd/os-time.h
+++ b/bsd-user/freebsd/os-time.h
@@ -764,7 +764,7 @@ static inline abi_long do_freebsd_clock_getcpuclockid2(abi_ulong arg1 __unused,
 }
 #endif /* ! __FreeBSD_version >= 902503 */
 
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 1100056
+#if defined(__FreeBSD_version) && ((__FreeBSD__ == 10 && __FreeBSD_version >= 1003000) || __FreeBSD_version >= 1100056)
 
 static inline abi_long do_freebsd_futimens(abi_ulong arg1,
         abi_ulong arg2)


### PR DESCRIPTION
Poudriere doesn’t work with qemu-bsd-user in 10.3, because 10.3’s pkg(8) requires utimensat() to work but os-time.h thinks it’s only available in 11.0. Qemu is returning ENOSYS, so pkg aborts.

There's probably a cleaner way of doing this #if macro.
