### PR TITLE
Don't try to copy the eventlist if the number of events is 0

### DIFF
--- a/bsd-user/freebsd/os-time.h
+++ b/bsd-user/freebsd/os-time.h
@@ -606,6 +606,10 @@ static inline abi_long do_freebsd_kevent(abi_long arg1, abi_ulong arg2,
     }
     ret = get_errno(kevent(arg1, changelist, arg3, eventlist, arg5,
                 arg6 != 0 ? &ts : NULL));
+
+    if (arg5 == 0)
+        return ret;
+
     if (!is_error(ret)) {
         target_eventlist = lock_user(VERIFY_WRITE, arg4,
                 sizeof(struct target_freebsd_kevent) * arg5, 0);


### PR DESCRIPTION
I'm seeing this error message:
/usr/local/bin/ghc
kevent: failed (Bad address)

here is the syscall trace (nevents and *eventlist are both 0):
kevent(8,-347058624,1,0,0,-347058648) = -1 errno=14 (Bad address)