### PR TITLE
Fix typo in  fork_end() in bsd-user/main.c.

### DIFF
--- a/bsd-user/main.c
+++ b/bsd-user/main.c
@@ -104,7 +104,7 @@ void fork_end(int child)
          */
         CPU_FOREACH_SAFE(cpu, next_cpu) {
             if (cpu != thread_cpu) {
-                QTAILQ_REMOVE(&cpus, thread_cpu, node);
+                QTAILQ_REMOVE(&cpus, cpu, node);
             }
         }
         qemu_mutex_init(&tcg_ctx.tb_ctx.tb_lock);


### PR DESCRIPTION
If emulated program starts new thread first and
then do fork(), then qemu fails with SISEGV.
This issue can be observed in python scons or Waf.