### PR TITLE
rlim_t is an int64_t, not an abi_ulong.  fixes getrlimit/setrlimit

### DIFF
--- a/bsd-user/bsd-proc.c
+++ b/bsd-user/bsd-proc.c
@@ -76,12 +76,12 @@ int target_to_host_resource(int code)
     }
 }
 
-rlim_t target_to_host_rlim(abi_ulong target_rlim)
+rlim_t target_to_host_rlim(abi_llong target_rlim)
 {
-    abi_ulong target_rlim_swap;
+    abi_llong target_rlim_swap;
     rlim_t result;
 
-    target_rlim_swap = tswapal(target_rlim);
+    target_rlim_swap = tswap64(target_rlim);
     if (target_rlim_swap == TARGET_RLIM_INFINITY) {
         return RLIM_INFINITY;
     }
@@ -94,17 +94,17 @@ rlim_t target_to_host_rlim(abi_ulong target_rlim)
     return result;
 }
 
-abi_ulong host_to_target_rlim(rlim_t rlim)
+abi_llong host_to_target_rlim(rlim_t rlim)
 {
-    abi_ulong target_rlim_swap;
-    abi_ulong result;
+    abi_llong target_rlim_swap;
+    abi_llong result;
 
-    if (rlim == RLIM_INFINITY || rlim != (abi_long)rlim) {
+    if (rlim == RLIM_INFINITY || rlim != (abi_llong)rlim) {
         target_rlim_swap = TARGET_RLIM_INFINITY;
     } else {
         target_rlim_swap = rlim;
     }
-    result = tswapal(target_rlim_swap);
+    result = tswap64(target_rlim_swap);
 
     return result;
 }

--- a/bsd-user/qemu-bsd.h
+++ b/bsd-user/qemu-bsd.h
@@ -44,8 +44,8 @@ abi_long host_to_target_shmid_ds(abi_ulong target_addr,
 
 /* bsd-proc.c */
 int target_to_host_resource(int code);
-rlim_t target_to_host_rlim(abi_ulong target_rlim);
-abi_ulong host_to_target_rlim(rlim_t rlim);
+rlim_t target_to_host_rlim(abi_llong target_rlim);
+abi_llong host_to_target_rlim(rlim_t rlim);
 abi_long host_to_target_rusage(abi_ulong target_addr,
         const struct rusage *rusage);
 #if defined(__FreeBSD_version) && __FreeBSD_version >= 1000000

--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -247,7 +247,7 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
         break;
 
     case TARGET_FREEBSD_NR_wait6: /* wait6(2) */
-        ret = do_freebsd_wait6(arg1, arg2, arg3, arg4, arg5, arg6);
+        ret = do_freebsd_wait6(cpu_env, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8);
         break;
 
     case TARGET_FREEBSD_NR_exit: /* exit(2) */

--- a/bsd-user/syscall_defs.h
+++ b/bsd-user/syscall_defs.h
@@ -263,11 +263,8 @@ struct target_freebsd_kevent {
 /*
  *  sys/resource.h
  */
-#if defined(__FreeBSD__) && defined(TARGET_ALPHA)
-#define TARGET_RLIM_INFINITY    0x7fffffffffffffffull
-#elif defined(__FreeBSD__) && (defined(TARGET_MIPS) || \
-        (defined(TARGET_SPARC) && TARGET_ABI_BITS == 32))
-#define TARGET_RLIM_INFINITY    0x7fffffffUL
+#if defined(__FreeBSD__) 
+#define TARGET_RLIM_INFINITY    RLIM_INFINITY
 #else
 #define TARGET_RLIM_INFINITY    ((abi_ulong)-1)
 #endif


### PR DESCRIPTION
not sure whether the convention for 64-bit types is to use abi_llong or a direct int64_t (I picked abi_llong). 