### PR TITLE
Implement fdatasync(2) for FreeBSD.

### DIFF
--- a/bsd-user/bsd-file.h
+++ b/bsd-user/bsd-file.h
@@ -238,6 +238,15 @@ static inline abi_long do_bsd_close(abi_long arg1)
     return get_errno(close(arg1));
 }
 
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1100502
+/* fdatasync(2) */
+static inline abi_long do_bsd_fdatasync(abi_long arg1)
+{
+
+    return get_errno(fdatasync(arg1));
+}
+#endif
+
 /* fsync(2) */
 static inline abi_long do_bsd_fsync(abi_long arg1)
 {

--- a/bsd-user/freebsd/strace.list
+++ b/bsd-user/freebsd/strace.list
@@ -91,6 +91,7 @@
 { TARGET_FREEBSD_NR_fchmod, "fchmod", "%s(%d,%#o)", NULL, NULL },
 { TARGET_FREEBSD_NR_fchown, "fchown", "%s(%d,%d,%d)", NULL, NULL },
 { TARGET_FREEBSD_NR_fcntl, "fcntl", NULL, NULL, NULL },
+{ TARGET_FREEBSD_NR_fdatasync, "fdatafsync", NULL, NULL, NULL },
 { TARGET_FREEBSD_NR_fexecve, "fexecve", NULL, print_execve, NULL },
 { TARGET_FREEBSD_NR_fhopen, "fhopen", NULL, NULL, NULL },
 { TARGET_FREEBSD_NR_fhstat, "fhstat", NULL, NULL, NULL },

--- a/bsd-user/freebsd/strace.list
+++ b/bsd-user/freebsd/strace.list
@@ -91,7 +91,7 @@
 { TARGET_FREEBSD_NR_fchmod, "fchmod", "%s(%d,%#o)", NULL, NULL },
 { TARGET_FREEBSD_NR_fchown, "fchown", "%s(%d,%d,%d)", NULL, NULL },
 { TARGET_FREEBSD_NR_fcntl, "fcntl", NULL, NULL, NULL },
-{ TARGET_FREEBSD_NR_fdatasync, "fdatafsync", NULL, NULL, NULL },
+{ TARGET_FREEBSD_NR_fdatasync, "fdatasync", NULL, NULL, NULL },
 { TARGET_FREEBSD_NR_fexecve, "fexecve", NULL, print_execve, NULL },
 { TARGET_FREEBSD_NR_fhopen, "fhopen", NULL, NULL, NULL },
 { TARGET_FREEBSD_NR_fhstat, "fhstat", NULL, NULL, NULL },

--- a/bsd-user/freebsd/syscall_nr.h
+++ b/bsd-user/freebsd/syscall_nr.h
@@ -466,10 +466,9 @@
 #define	TARGET_FREEBSD_NR_pipe2	542
 #define	TARGET_FREEBSD_NR_aio_mlock	543
 #define	TARGET_FREEBSD_NR_procctl	544
-#define	TARGET_FREEBSD_NR_ppoll		545
+#define	TARGET_FREEBSD_NR_ppoll	545
 #define	TARGET_FREEBSD_NR_futimens	546
 #define	TARGET_FREEBSD_NR_utimensat	547
-
 #define	TARGET_FREEBSD_NR_MAXSYSCALL	548
 /* Legacy system calls. */
 #ifndef	TARGET_FREEBSD_NR_killpg

--- a/bsd-user/freebsd/syscall_nr.h
+++ b/bsd-user/freebsd/syscall_nr.h
@@ -469,7 +469,10 @@
 #define	TARGET_FREEBSD_NR_ppoll	545
 #define	TARGET_FREEBSD_NR_futimens	546
 #define	TARGET_FREEBSD_NR_utimensat	547
-#define	TARGET_FREEBSD_NR_MAXSYSCALL	548
+#define	TARGET_FREEBSD_NR_numa_getaffinity	548
+#define	TARGET_FREEBSD_NR_numa_setaffinity	549
+#define	TARGET_FREEBSD_NR_fdatasync	550
+#define	TARGET_FREEBSD_NR_MAXSYSCALL	551
 /* Legacy system calls. */
 #ifndef	TARGET_FREEBSD_NR_killpg
 #define	TARGET_FREEBSD_NR_killpg	146

--- a/bsd-user/syscall.c
+++ b/bsd-user/syscall.c
@@ -553,6 +553,12 @@ abi_long do_freebsd_syscall(void *cpu_env, int num, abi_long arg1,
         ret = do_bsd_close(arg1);
         break;
 
+#if defined(__FreeBSD_version) && __FreeBSD_version >= 1100502
+    case TARGET_FREEBSD_NR_fdatasync: /* fdatasync(2) */
+        ret = do_bsd_fdatasync(arg1);
+        break;
+#endif
+
     case TARGET_FREEBSD_NR_fsync: /* fsync(2) */
         ret = do_bsd_fsync(arg1);
         break;


### PR DESCRIPTION
This removes annoying noise, i.e., `qemu: unsupported syscall: 550 (calling anyway)`.