### PR TITLE
Disable the FPU for both 32-bit mips targets.

### DIFF
--- a/bsd-user/mips/target_arch_cpu.h
+++ b/bsd-user/mips/target_arch_cpu.h
@@ -22,7 +22,7 @@
 
 #include "target_arch.h"
 
-#if defined(TARGET_ABI_MIPSN32)
+#if defined(TARGET_ABI_MIPSN32) || defined(TARGET_ABI_MIPSO32)
 #  define TARGET_DEFAULT_CPU_MODEL "24Kc"
 #else
 #  define TARGET_DEFAULT_CPU_MODEL "24Kf"


### PR DESCRIPTION
FreeBSD-mips is softfloat, so don't permit qemu to execute instructions that
real hardware can't.