### PR TITLE
Add missing parts for bsd-user

### DIFF
--- a/bsd-user/aarch64/target_arch_cpu.h
+++ b/bsd-user/aarch64/target_arch_cpu.h
@@ -151,6 +151,10 @@ static inline void target_cpu_loop(CPUARMState *env)
             }
             break;
 
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
             fprintf(stderr, "qemu: unhandled CPU exception 0x%x - aborting\n",
                     trapnr);

--- a/bsd-user/arm/target_arch_cpu.h
+++ b/bsd-user/arm/target_arch_cpu.h
@@ -317,6 +317,9 @@ static inline void target_cpu_loop(CPUARMState *env)
                 }
             }
             break;
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
         default:
             fprintf(stderr, "qemu: unhandled CPU exception 0x%x - aborting\n",
                     trapnr);

--- a/bsd-user/i386/target_arch_cpu.h
+++ b/bsd-user/i386/target_arch_cpu.h
@@ -281,6 +281,11 @@ static inline void target_cpu_loop(CPUX86State *env)
             }
             break;
 #endif
+
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
             pc = env->segs[R_CS].base + env->eip;
             fprintf(stderr, "qemu: 0x%08lx: unhandled CPU exception 0x%x - "

--- a/bsd-user/mips/target_arch_cpu.h
+++ b/bsd-user/mips/target_arch_cpu.h
@@ -233,6 +233,10 @@ static inline void target_cpu_loop(CPUMIPSState *env)
             }
             break;
 
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
             fprintf(stderr, "qemu: unhandled CPU exception "
                 "0x%x - aborting\n", trapnr);

--- a/bsd-user/mips64/target_arch_cpu.h
+++ b/bsd-user/mips64/target_arch_cpu.h
@@ -220,6 +220,10 @@ static inline void target_cpu_loop(CPUMIPSState *env)
             }
             break;
 
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
             fprintf(stderr, "qemu: unhandled CPU exception "
                 "0x%x - aborting\n", trapnr);

--- a/bsd-user/ppc/target_arch_cpu.h
+++ b/bsd-user/ppc/target_arch_cpu.h
@@ -537,6 +537,9 @@ static inline void target_cpu_loop(CPUPPCState *env)
                   }
             }
             break;
+        case EXCP_ATOMIC:
+            cpu_exec_step_atomic(cs);
+            break;
         case EXCP_INTERRUPT:
             /* just indicate that signals should be handled asap */
             break;

--- a/bsd-user/sparc/target_arch_cpu.h
+++ b/bsd-user/sparc/target_arch_cpu.h
@@ -134,6 +134,11 @@ static inline void target_cpu_loop(CPUSPARCState *env)
             }
 #endif
             break;
+
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
             printf("Unhandled trap: 0x%x\n", trapnr);
             cpu_dump_state(cs, stderr, fprintf, 0);

--- a/bsd-user/sparc64/target_arch_cpu.h
+++ b/bsd-user/sparc64/target_arch_cpu.h
@@ -258,6 +258,10 @@ static inline void target_cpu_loop(CPUSPARCState *env)
             }
             break;
 
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
 badtrap:
             printf("Unhandled trap: 0x%x\n", trapnr);

--- a/bsd-user/x86_64/target_arch_cpu.h
+++ b/bsd-user/x86_64/target_arch_cpu.h
@@ -296,6 +296,11 @@ static inline void target_cpu_loop(CPUX86State *env)
             }
             break;
 #endif
+
+        case EXCP_ATOMIC:
+            step_atomic(cs);
+            break;
+
         default:
             pc = env->segs[R_CS].base + env->eip;
             fprintf(stderr, "qemu: 0x%08lx: unhandled CPU exception 0x%x - "


### PR DESCRIPTION
From linux-user fdbc2b5722f6092e47181a947c90fd4bdcc1c121

tcg: Add EXCP_ATOMIC
When we cannot emulate an atomic operation within a parallel
context, this exception allows us to stop the world and try
again in a serial context.

Reviewed-by: Emilio G. Cota <cota@braap.org>
Reviewed-by: Alex Bennée <alex.bennee@linaro.org>
Signed-off-by: Richard Henderson <rth@twiddle.net>