### PR TITLE
To update the host kernel signal state we want to use sa_sigaction

### DIFF
--- a/bsd-user/signal.c
+++ b/bsd-user/signal.c
@@ -573,6 +573,7 @@ int do_sigaction(int sig, const struct target_sigaction *act,
         if (host_sig != SIGSEGV && host_sig != SIGBUS) {
             memset(&act1, 0, sizeof(struct sigaction));
             sigfillset(&act1.sa_mask);
+            act1.sa_flags = SA_SIGINFO;
             if (k->sa_flags & TARGET_SA_RESTART) {
                 act1.sa_flags |= SA_RESTART;
             }
@@ -584,13 +585,11 @@ int do_sigaction(int sig, const struct target_sigaction *act,
                 act1.sa_sigaction = (void *)SIG_IGN;
             } else if (k->_sa_handler == TARGET_SIG_DFL) {
                 if (fatal_signal(sig)) {
-                    act1.sa_flags = SA_SIGINFO;
                     act1.sa_sigaction = host_signal_handler;
                 } else {
                     act1.sa_sigaction = (void *)SIG_DFL;
                 }
             } else {
-                act1.sa_flags = SA_SIGINFO;
                 act1.sa_sigaction = host_signal_handler;
             }
             ret = sigaction(host_sig, &act1, NULL);


### PR DESCRIPTION
but SA_SIGINFO is missing in some cases.
This can cause unexpected interrupted syscalls.
Set SA_SIGINFO earlier.

From linux-user.