### PR TITLE
Merge https://github.com/seanbruno/qemu-bsd-user/commit/b936cb50aacf3…

### DIFF
--- a/bsd-user/freebsd/os-proc.c
+++ b/bsd-user/freebsd/os-proc.c
@@ -182,13 +182,13 @@ abi_long freebsd_exec_common(abi_ulong path_or_fd, abi_ulong guest_argp,
         envc++;
     }
 
-    qarg0 = argp =  alloca((argc + 7) * sizeof(void *));
+    qarg0 = argp = g_new0(char *, argc + 7);
     /* save the first agrument for the emulator */
     *argp++ = (char *)getprogname();
     qargp = argp;
     *argp++ = (char *)getprogname();
     qarg1 = argp;
-    envp = alloca((envc + 1) * sizeof(void *));
+    envp = g_new0(char *, envc + 1);
     for (gp = guest_argp, q = argp; gp; gp += sizeof(abi_ulong), q++) {
         if (get_user_ual(addr, gp)) {
             ret = -TARGET_EFAULT;
@@ -360,6 +360,10 @@ execve_end:
         }
         unlock_user(*q, addr, 0);
     }
+
+    g_free(qarg0);
+    g_free(envp);
+
     return ret;
 }
 


### PR DESCRIPTION
…cccf5d2363095c6547eb709583a from linux-user

linux-user: allocate heap memory for execve arguments
Arguments passed to execve(2) call from user program could
be large, allocating stack memory for them via alloca(3) call
would lead to bad behaviour. Use 'g_new0' to allocate memory
for such arguments.

Reported-by: Jann Horn <jannh@google.com>
Signed-off-by: Prasad J Pandit <pjp@fedoraproject.org>
Reviewed-by: Eric Blake <eblake@redhat.com>
Signed-off-by: Riku Voipio <riku.voipio@linaro.org>