### PR TITLE
Fix lock order reversion for mmap and tb locks. 

### DIFF
--- a/bsd-user/main.c
+++ b/bsd-user/main.c
@@ -88,8 +88,8 @@ char qemu_proc_pathname[PATH_MAX];  /* full path to exeutable */
 void fork_start(void)
 {
     cpu_list_lock();
-    qemu_mutex_lock(&tcg_ctx.tb_ctx.tb_lock);
     mmap_fork_start();
+    qemu_mutex_lock(&tcg_ctx.tb_ctx.tb_lock);
 }
 
 void fork_end(int child)
@@ -107,10 +107,12 @@ void fork_end(int child)
             }
         }
         qemu_mutex_init(&tcg_ctx.tb_ctx.tb_lock);
+        mmap_fork_end(child);
 	qemu_init_cpu_list();
         gdbserver_fork(thread_cpu);
     } else {
         qemu_mutex_unlock(&tcg_ctx.tb_ctx.tb_lock);
+        mmap_fork_end(child);
 	cpu_list_unlock();
     }
 


### PR DESCRIPTION
These locks are taken in different order in accel/tcg/cpu-exec.c and in bsd-user/mmap.c. which leads to livelock visible mainly in automoc4.
