### PR TITLE
Support/log more operations for user mode mutexes.

### DIFF
--- a/bsd-user/freebsd/os-thread.c
+++ b/bsd-user/freebsd/os-thread.c
@@ -1300,6 +1300,24 @@ abi_long freebsd_rw_unlock(abi_ulong target_addr)
     }
 }
 
+#if defined(__FreeBSD_version) && __FreeBSD_version > 900000
+abi_long
+freebsd_umtx_shm(abi_ulong target_addr, long fflag)
+{
+
+    return get_errno(_umtx_op(NULL, UMTX_OP_SHM, fflag, g2h(target_addr), NULL));
+}
+
+abi_long
+freebsd_umtx_robust_list(abi_ulong target_addr, size_t rbsize)
+{
+
+    gemu_log("_umtx_op(..., UMTX_OP_ROBUST_LISTS. ...)  not yet supported\n");
+    return -TARGET_EOPNOTSUPP;
+}
+
+#endif /* __FreeBSD_version > 1200000 */
+
 abi_long do_freebsd_thr_new(CPUArchState *env,
         abi_ulong target_param_addr, int32_t param_size)
 {

--- a/bsd-user/freebsd/os-thread.h
+++ b/bsd-user/freebsd/os-thread.h
@@ -523,6 +523,15 @@ static inline abi_long do_freebsd__umtx_op(abi_ulong obj, int op, abi_ulong val,
         /* Don't need to do access_ok(). */
         ret = freebsd_umtx_sem_wake(obj);
         break;
+#if __FreeBSD_version > 1200000
+    case UMTX_OP_SHM:
+        ret = freebsd_umtx_shm(uaddr, val);
+        break;
+    case TARGET_UMTX_OP_ROBUST_LISTS:
+        ret = freebsd_umtx_robust_list(uaddr, val);
+        break;
+#endif /* __FreeBSD_version > 1200000 */
+
 #endif
     default:
         return -TARGET_EINVAL;

--- a/bsd-user/qemu.h
+++ b/bsd-user/qemu.h
@@ -326,7 +326,10 @@ abi_long freebsd_rw_rdlock(abi_ulong target_addr, long fflag,
 abi_long freebsd_rw_wrlock(abi_ulong target_addr, long fflag,
         size_t tsz, void *t);
 abi_long freebsd_rw_unlock(abi_ulong target_addr);
-
+#if defined(__FreeBSD_version) && __FreeBSD_version > 1200000
+abi_long freebsd_umtx_shm(abi_ulong target_addr, long fflag);
+abi_long freebsd_umtx_robust_list(abi_ulong target_addr, size_t rbsize);
+#endif /* __FreeBSD_version > 1200000 */
 
 /* user access */
 

--- a/bsd-user/syscall_defs.h
+++ b/bsd-user/syscall_defs.h
@@ -731,7 +731,8 @@ typedef struct {
 #define TARGET_UMTX_OP_MUTEX_WAKE2          22
 #define TARGET_UMTX_OP_SEM2_WAIT            23
 #define TARGET_UMTX_OP_SEM2_WAKE            24
-#define TARGET_UMTX_OP_MAX                  25
+#define TARGET_UMTX_OP_SHM                  25
+#define TARGET_UMTX_OP_ROBUST_LISTS         26
 
 /* flags for UMTX_OP_CV_WAIT */
 #define TARGET_CVWAIT_CHECK_UNPARKING       0x01


### PR DESCRIPTION
- implement UMTX_OP_SHM mutex operation.
- log UMTX_OP_ROBUST_LISTS as not yet implemented.

This fixes autoconf test 'checking if Berkeley DB supports shared environments',  used e.g. in mail/bogofilter
