### PR TITLE
sendmsg()/recvmsg() fixes.

### DIFF
--- a/bsd-user/freebsd/os-socket.c
+++ b/bsd-user/freebsd/os-socket.c
@@ -58,12 +58,8 @@ abi_long t2h_freebsd_cmsg(struct msghdr *msgh,
         cmsg->cmsg_type = tswap32(target_cmsg->cmsg_type);
         cmsg->cmsg_len = CMSG_LEN(len);
 
-        if (cmsg->cmsg_level != TARGET_SOL_SOCKET ||
-            cmsg->cmsg_type != SCM_RIGHTS) {
-            gemu_log("Unsupported ancillary data: %d/%d\n",
-                cmsg->cmsg_level, cmsg->cmsg_type);
-            memcpy(data, target_data, len);
-        } else {
+        if ((cmsg->cmsg_level == TARGET_SOL_SOCKET) &&
+            (cmsg->cmsg_type == SCM_RIGHTS)) {
             int *fd = (int *)data;
             int *target_fd = (int *)target_data;
             int i, numfds = len / sizeof(int);
@@ -71,6 +67,19 @@ abi_long t2h_freebsd_cmsg(struct msghdr *msgh,
             for (i = 0; i < numfds; i++) {
                 fd[i] = tswap32(target_fd[i]);
             }
+        } else if ((cmsg->cmsg_level == TARGET_SOL_SOCKET) &&
+            (cmsg->cmsg_type == SCM_TIMESTAMP) &&
+            (len == sizeof(struct timeval)))  {
+            /* copy struct timeval to host */
+            struct timeval *tv = (struct timeval *)data;
+            struct target_freebsd_timeval *target_tv =
+                (struct target_freebsd_timeval *)target_data;
+            __get_user(tv->tv_sec, &target_tv->tv_sec);
+            __get_user(tv->tv_usec, &target_tv->tv_usec);
+        } else {
+            gemu_log("Unsupported ancillary data: %d/%d\n",
+                cmsg->cmsg_level, cmsg->cmsg_type);
+            memcpy(data, target_data, len);
         }
         cmsg = CMSG_NXTHDR(msgh, cmsg);
         target_cmsg = TARGET_CMSG_NXTHDR(target_msgh, target_cmsg);
@@ -120,11 +129,12 @@ abi_long h2t_freebsd_cmsg(struct target_msghdr *target_msgh,
             int *fd = (int *)data;
             int *target_fd = (int *)target_data;
             int i, numfds = len / sizeof(int);
+
             for (i = 0; i < numfds; i++) {
                 target_fd[i] = tswap32(fd[i]);
             }
         } else if ((cmsg->cmsg_level == TARGET_SOL_SOCKET) &&
-            (cmsg->cmsg_type == SO_TIMESTAMP) &&
+            (cmsg->cmsg_type == SCM_TIMESTAMP) &&
             (len == sizeof(struct timeval))) {
             /* copy struct timeval to target */
             struct timeval *tv = (struct timeval *)data;

--- a/bsd-user/syscall_defs.h
+++ b/bsd-user/syscall_defs.h
@@ -429,7 +429,7 @@ static inline struct target_cmsghdr *__target_cmsg_nxthdr(
         /* No more entries.  */
         return (struct target_cmsghdr *)0;
     }
-    return __cmsg;
+    return __ptr;
 }
 
 /*


### PR DESCRIPTION
- return right pointer from TARGET_CMSG_NXTHDR()
- in recvmsg(), add  support for SCM_TIMESTAMP control message
- in sendmsg(), timestamp control message have SCM_TIMESTAMP type, not SO_TIMESTAMP

This fixes:
- runaway processes found in sysutils/bareos-client
- 'Host cmsg overflow' message reported for ping a.b.c.d
