### PR TITLE
Stop using basename_r(3).

### DIFF
--- a/bsd-user/elfload.c
+++ b/bsd-user/elfload.c
@@ -1602,12 +1602,11 @@ static int core_dump_filename(const TaskState *ts, char *buf,
     }
 
     filename = strdup(ts->bprm->filename);
-    base_filename = strdup(basename(filename));
+    base_filename = basename(filename);
     (void) strftime(timestamp, sizeof (timestamp), "%Y%m%d-%H%M%S",
             localtime_r(&tv.tv_sec, &tm));
     (void) snprintf(buf, bufsize, "qemu_%s_%s_%d.core",
             base_filename, timestamp, (int)getpid());
-    free(base_filename);
     free(filename);
 #else /* ! QEMU_LONG_CORE_FILENAME */
     char *filename, *base_filename;
@@ -1615,9 +1614,8 @@ static int core_dump_filename(const TaskState *ts, char *buf,
     assert(bufsize >= PATH_MAX);
 
     filename = strdup(ts->bprm->filename);
-    base_filename = strdup(basename(filename));
+    base_filename = basename(filename);
     (void) snprintf(buf, bufsize, "qemu_%s.core", base_filename);
-    free(base_filename);
     free(filename);
 #endif /* ! QEMU_LONG_CORE_FILENAME */
 

--- a/bsd-user/elfload.c
+++ b/bsd-user/elfload.c
@@ -1610,23 +1610,15 @@ static int core_dump_filename(const TaskState *ts, char *buf,
     free(base_filename);
     free(filename);
 #else /* ! QEMU_LONG_CORE_FILENAME */
-#if defined(__FreeBSD_version) && __FreeBSD_version >= 900000
-    char bname[MAXPATHLEN + 1];
-    char *filename;
+    char *filename, *base_filename;
 
     assert(bufsize >= PATH_MAX);
 
-    filename = basename_r(ts->bprm->filename, bname);
-    (void) snprintf(buf, bufsize, "qemu_%s.core", filename);
-#else /* ! __FreeBSD_version >= 900000 */
-    char *filename;
-
-    assert(bufsize >= PATH_MAX);
-
-    filename = strdup(basename(ts->bprm->filename));
-    (void) snprintf(buf, bufsize, "qemu_%s.core", filename);
+    filename = strdup(ts->bprm->filename);
+    base_filename = strdup(basename(filename));
+    (void) snprintf(buf, bufsize, "qemu_%s.core", base_filename);
+    free(base_filename);
     free(filename);
-#endif /* ! __FreeBSD_version >= 900000 */
 #endif /* ! QEMU_LONG_CORE_FILENAME */
 
     return (0);


### PR DESCRIPTION
This function has been removed from FreeBSD in r326719. We should just
use POSIX basename(3). Extend the already existing code that calls
basename(3) to properly use strdup(3) to not overwrite the input string.