### PR TITLE
SysV IPC cleanup

### DIFF
--- a/bsd-user/bsd-misc.c
+++ b/bsd-user/bsd-misc.c
@@ -166,8 +166,8 @@ abi_long target_to_host_msqid_ds(struct msqid_ds *host_md,
         return -TARGET_EFAULT;
     }
 
+    memset(host_md, 0, sizeof(struct msqid_ds);
     /* msg_first and msg_last are not used by IPC_SET/IPC_STAT in kernel. */
-    host_md->msg_first = host_md->msg_last = NULL;
     host_md->msg_cbytes = tswapal(target_md->msg_cbytes);
     host_md->msg_qnum = tswapal(target_md->msg_qnum);
     host_md->msg_qbytes = tswapal(target_md->msg_qbytes);
@@ -193,6 +193,7 @@ abi_long host_to_target_msqid_ds(abi_ulong target_addr,
         return -TARGET_EFAULT;
     }
 
+    memset(target_md, 0, sizeof(struct target_msqid_ds);
     /* msg_first and msg_last are not used by IPC_SET/IPC_STAT in kernel. */
     target_md->msg_cbytes = tswapal(host_md->msg_cbytes);
     target_md->msg_qnum = tswapal(host_md->msg_qnum);

--- a/bsd-user/bsd-misc.h
+++ b/bsd-user/bsd-misc.h
@@ -277,12 +277,17 @@ static inline abi_long do_bsd_msgctl(int msgid, int target_cmd, abi_long ptr)
     return ret;
 }
 
+struct kern_mymsg {
+    long mtype;
+    char mtext[1];
+};
+
 /* msgsnd(2) */
 static inline abi_long do_bsd_msgsnd(int msqid, abi_long msgp,
         unsigned int msgsz, int msgflg)
 {
     struct target_msgbuf *target_mb;
-    struct mymsg *host_mb;
+    struct kern_mymsg *host_mb;
     abi_long ret;
 
     if (!lock_user_struct(VERIFY_READ, target_mb, msgp, 0)) {
@@ -304,7 +309,7 @@ static inline abi_long do_bsd_msgrcv(int msqid, abi_long msgp,
 {
     struct target_msgbuf *target_mb = NULL;
     char *target_mtext;
-    struct mymsg *host_mb;
+    struct kern_mymsg *host_mb;
     abi_long ret = 0;
 
     if (!lock_user_struct(VERIFY_WRITE, target_mb, msgp, 0)) {


### PR DESCRIPTION
Avoid a couple non-standard features in FreeBSD's SysV IPC implementation that I plan to break.  (This was literally the only use of both of them in the ports tree.)