### PR TITLE
Remove the packed attribute on struct target_freebsd_kevent

### DIFF
--- a/bsd-user/syscall_defs.h
+++ b/bsd-user/syscall_defs.h
@@ -280,7 +280,7 @@ struct target_freebsd11_kevent {
     uint32_t   fflags;
     abi_long   data;
     abi_ulong  udata;
-} __packed;
+};
 
 struct target_freebsd_kevent {
     abi_ulong  ident;
@@ -290,7 +290,7 @@ struct target_freebsd_kevent {
     int64_t data;
     abi_ulong  udata;
     uint64_t  ext[4];
-} __packed;
+};
 
 /*
  *  sys/resource.h


### PR DESCRIPTION
The size of "struct target_freebsd_kevent" doesn't match
the size of "struct kevent" on the target architecture.

The issue can be demonstrated with:

cat -> kevent_dump  <<EOF
p/d sizeof(struct target_freebsd_kevent)
p/d &((struct target_freebsd_kevent *)0)->ident
p/d &((struct target_freebsd_kevent *)0)->filter
p/d &((struct target_freebsd_kevent *)0)->flags
p/d &((struct target_freebsd_kevent *)0)->fflags
p/d &((struct target_freebsd_kevent *)0)->data
p/d &((struct target_freebsd_kevent *)0)->udata
p/d &((struct target_freebsd_kevent *)0)->ext
quit
EOF

gdb -batch -nx -x kevent_dump work/stage/usr/local/bin/qemu-arm-static 2> /dev/null

$1 = 56
$2 = 0
$3 = 4
$4 = 6
$5 = 8
$6 = 12
$7 = 20
$8 = 24

on the target arch:

int
main()
{
        printf("sizeof kevent %d\n", sizeof(struct kevent));
        printf("ident %d\n",  &((struct kevent *)0)->ident);
        printf("filter %d\n", &((struct kevent *)0)->filter);
        printf("flags %d\n",  &((struct kevent *)0)->flags);
        printf("fflags %d\n", &((struct kevent *)0)->fflags);
        printf("data %d\n",   &((struct kevent *)0)->data);
        printf("udata %d\n",  &((struct kevent *)0)->udata);
        printf("ext %d\n",    &((struct kevent *)0)->ext);
        return 0;
}

izeof kevent 64
ident 0
filter 4
flags 6
fflags 8
data 16
udata 24
ext 32