### PR TITLE
bsd-user: freebsd: Fix context handling on powerpc.

### DIFF
--- a/bsd-user/freebsd/target_os_signal.h
+++ b/bsd-user/freebsd/target_os_signal.h
@@ -42,7 +42,6 @@
 #define TARGET_SIGLIBRT 33     /* reserved by the real-time library */
 #define TARGET_SIGRTMIN 65
 #define TARGET_SIGRTMAX 126
-#define TARGET_QEMU_ESIGRETURN  255 /* fake errno value for use by sigreturn */
 
 /*
  * Language spec says we must list exactly one parameter, even though we

--- a/bsd-user/ppc/target_arch_cpu.h
+++ b/bsd-user/ppc/target_arch_cpu.h
@@ -436,7 +436,7 @@ static inline void target_cpu_loop(CPUPPCState *env)
             ret = do_freebsd_syscall(env, env->gpr[0], env->gpr[3], env->gpr[4],
                              env->gpr[5], env->gpr[6], env->gpr[7],
                              env->gpr[8], env->gpr[9], env->gpr[10]);
-            if (ret == (target_ulong)(-TARGET_QEMU_ESIGRETURN)) {
+            if (ret == (target_ulong)(-TARGET_EJUSTRETURN)) {
                 /* Returning from a successful sigreturn syscall.
                    Avoid corrupting register state.  */
                 break;


### PR DESCRIPTION
Due to a mismatch between the qemu CPU model and the FreeBSD trapframe
layout, we need to manually handle the extra registers that are stored
in the trapframe rather than copying past the end of the gpr array.

Doing this properly fixes oddities like signal handlers screwing up
condition register fields and causing spurious signal errors.

This also stops the signal handling from scribbling in some of the
SPE high half of the GPRs, as that's what was next in the struct.

Signed-off-by: Brandon Bergren <bdragon@FreeBSD.org>