### PR TITLE
Skip YIELD

### DIFF
--- a/bsd-user/aarch64/target_arch_cpu.h
+++ b/bsd-user/aarch64/target_arch_cpu.h
@@ -156,6 +156,9 @@ static inline void target_cpu_loop(CPUARMState *env)
             cpu_exec_step_atomic(cs);
             break;
 
+        case EXCP_YIELD:
+            break;
+
         default:
             fprintf(stderr, "qemu: unhandled CPU exception 0x%x - aborting\n",
                     trapnr);


### PR DESCRIPTION
It's an optional hint and is NOP if not implemented, so we can skip it. Fixes #154 